### PR TITLE
Fix failing tests and update the title element for the home page

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org" lang="en"> 
   <head>
-    <title>Title of your page goes here</title>
+    <title>CS56 Spring Boot Practice App</title>
     <div th:replace="bootstrap/bootstrap_head.html"></div>
   </head>
   <body>

--- a/src/main/resources/templates/page1.html
+++ b/src/main/resources/templates/page1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org" lang="en"> 
   <head>
-    <title>Title of your page goes here</title>
+    <title>CS56 Spring Boot Practice App</title>
     <div th:replace="bootstrap/bootstrap_head.html"></div>
   </head>
   <body>

--- a/src/main/resources/templates/page2.html
+++ b/src/main/resources/templates/page2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org" lang="en"> 
   <head>
-    <title>Title of your page goes here</title>
+    <title>CS56 Spring Boot Practice App/title>
     <div th:replace="bootstrap/bootstrap_head.html"></div>
   </head>
   <body>

--- a/src/test/java/hello/HomePageTest.java
+++ b/src/test/java/hello/HomePageTest.java
@@ -39,7 +39,7 @@ public class HomePageTest {
                 .andExpect(xpath(BootstrapLiterals.bootstrapCSSXpath).exists());
         for (String s: BootstrapLiterals.bootstrapJSurls) {
             String jsXPath = String.format("//script[@src='%s']",s);
-            mvc.perform(MockMvcRequestBuilders.get("/greeting").accept(MediaType.TEXT_HTML))
+            mvc.perform(MockMvcRequestBuilders.get("/").accept(MediaType.TEXT_HTML))
               .andExpect(status().isOk())
               .andExpect(xpath(jsXPath).exists());
         }

--- a/src/test/java/hello/HomePageTest.java
+++ b/src/test/java/hello/HomePageTest.java
@@ -51,6 +51,6 @@ public class HomePageTest {
         mvc.perform(MockMvcRequestBuilders.get("/").accept(MediaType.TEXT_HTML))
                 .andExpect(status().isOk())
                 .andExpect(xpath("//title").exists())
-                .andExpect(xpath("//title").string("Getting Started: Serving Web Content"));
+                .andExpect(xpath("//title").string("CS56 Spring Boot Practice App"));
     }
 }


### PR DESCRIPTION
In this PR we fix two failing tests:
- The title element on the home page was incorrect
- There was a typo in the test case for bootstrap js/css flies